### PR TITLE
Tags Problem Solved

### DIFF
--- a/layouts/Bloglayout.jsx
+++ b/layouts/Bloglayout.jsx
@@ -65,11 +65,11 @@ const Blog = (props) => {
             </div>
 
             <div className="mt-5 lg:mb-8">
-              <div className="flex flex-wrap gap-2 text-center">
+              <div className="flex flex-wrap text-center -mx-1">
                 {tags.map((name) => (
                   <div
                     key={name}
-                    className="bg-gray-100 dark:bg-gray-800 px-2 text-2xl flex-1 text-gray-600 dark:text-gray-200 rounded-sm text-tiny select-none md:text-sm md:px-4 md:py-2"
+                    className="bg-gray-100 m-1 dark:bg-gray-800 px-2 text-2xl flex-1 text-gray-600 dark:text-gray-200 rounded-sm text-tiny select-none md:text-sm md:px-4 md:py-2"
                   >
                     {name}
                   </div>


### PR DESCRIPTION
## Flex Gap Support Issue Resolved 
- On Safari Browser the flex-gap was not working properly so I implemented it with a custom margin

### Solution
- Added a margin of `4px` on all the children.
- Problem is now,  The parent has a margin on both sides.
![Screen Capture_select-area_20210422140501](https://user-images.githubusercontent.com/28804764/115695121-bf8ba300-a376-11eb-8fee-1ef2345cee53.png)

- Removed it from the parent element with a negative of `-4px` on both sides. 
![Screen Capture_select-area_20210422140613](https://user-images.githubusercontent.com/28804764/115695231-daf6ae00-a376-11eb-8b16-3e29db2020c8.png)

- Perfect Flex Gap-like feature which looks nice on all browsers now.

### Final Result
![image](https://user-images.githubusercontent.com/28804764/115695354-f6fa4f80-a376-11eb-9395-096a42b98326.png)

```diff
<div className="mt-5 lg:mb-8">
-  <div className="flex flex-wrap text-center gap-2">
+  <div className="flex flex-wrap text-center -mx-1">
    {tags.map((name) => (
      <div
        key={name}
       className="bg-gray-100 dark:bg-gray-800 px-2 text-2xl flex-1 text-gray-600 dark:text-gray-200 rounded-sm text-tiny select-none md:text-sm md:px-4 md:py-2"
+      className="bg-gray-100 m-1 dark:bg-gray-800 px-2 text-2xl flex-1 text-gray-600 dark:text-gray-200 rounded-sm text-tiny select-none md:text-sm md:px-4 md:py-2"
      >
        {name}
      </div>
    ))}
</div>
```
