### PR TITLE
Automatic Sitemap Generation

### DIFF
--- a/pages/api/sitemap.js
+++ b/pages/api/sitemap.js
@@ -1,25 +1,34 @@
 import { SitemapStream, streamToPromise } from 'sitemap'
 import { Readable } from 'stream'
+import { getAllFilesFrontMatter } from '@/utils/mdx'
 
 const Sitemap = async (req, res) => {
-  const links = [
-    { url: '/', changefreq: 'daily', priority: 0.3 },
-    { url: '/blog', changefreq: 'daily', priority: 0.3 },
-    { url: '/blog/github-authentication', changefreq: 'daily', priority: 0.3 },
-    { url: '/blog/portfolio-for-software-engineers', changefreq: 'daily', priority: 0.3 },
-  ]
+  //. Fetch All Posts
+  const posts = await getAllFilesFrontMatter('blog')
 
-  // Create a stream to write to
+  //. Read the all the posts and generate their links in the XML sitemap.
+  const links = posts.map((post) => {
+    return { url: `/blog/${post.slug}`, changefreq: 'daily', priority: 0.3 }
+  })
+
+  //. Push your own links into the mix if they are not on the blog array.
+  links.unshift({ url: `/blog/`, changefreq: 'daily', priority: 0.3 })
+  links.unshift({ url: `/`, changefreq: 'daily', priority: 0.3 })
+
+  //. Create a stream using incoming domain.
   const stream = new SitemapStream({ hostname: `https://${req.headers.host}` })
 
+  //. Send 200 Status Code with XML Format Included.
   res.writeHead(200, {
     'Content-Type': 'application/xml',
   })
 
+  //. Add the link into the stream.
   const xmlString = await streamToPromise(Readable.from(links).pipe(stream)).then((data) =>
     data.toString()
   )
 
+  //. Send XML output file.
   res.end(xmlString)
 }
 


### PR DESCRIPTION
## Automatic Sitemap Generation

- Sitemap is now automatically generated by fetching all the posts, reading the `slug` and building a link for them in the XML site map file.

- Super Cool. Don't have to touch this file again.  **Automated**
